### PR TITLE
数据库从pgsql修改为h2，不再需要连接本地数据库，方便下载demo使用；解决编译失败：AuthApi类中引入ParseExceptio…

### DIFF
--- a/leave-service/pom.xml
+++ b/leave-service/pom.xml
@@ -86,5 +86,12 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- 内存数据库，不再需要连接本地数据库，方便下载demo使用 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/leave-service/src/main/java/ddd/leave/interfaces/facade/AuthApi.java
+++ b/leave-service/src/main/java/ddd/leave/interfaces/facade/AuthApi.java
@@ -1,17 +1,16 @@
 package ddd.leave.interfaces.facade;
 
 import ddd.leave.application.service.LoginApplicationService;
-import ddd.leave.domain.person.entity.Person;
 import ddd.leave.infrastructure.common.api.Response;
-import ddd.leave.interfaces.assembler.LeaveAssembler;
 import ddd.leave.interfaces.assembler.PersonAssembler;
-import ddd.leave.interfaces.dto.LeaveDTO;
 import ddd.leave.interfaces.dto.PersonDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.text.ParseException;
 
 @RestController
 @RequestMapping("/auth")

--- a/leave-service/src/main/resources/application.yml
+++ b/leave-service/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/leave
+    driver-class-name: org.h2.Driver
     username: leave
     password: leave
   jpa:
@@ -12,3 +11,7 @@ spring:
         temp:
           use_jdbc_metadata_defaults: false
     show-sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console


### PR DESCRIPTION
1.数据库从pgsql修改为h2，不再需要连接本地数据库，方便下载demo使用；
2.解决编译失败：AuthApi类中引入ParseException的依赖；
3.删除类中没有被使用的依赖。